### PR TITLE
Remove references to "smallpeice"

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -4,8 +4,8 @@ import type * as Preset from "@docusaurus/preset-classic";
 import remarkDefList from 'remark-deflist';
 
 const config: Config = {
-    title: "Smallpeice Docs",
-    tagline: "Student documentation for the Smallpeice Computing, Robotics & Electronics Summer School.",
+    title: "Computing, Electronics and Robotics Docs",
+    tagline: "Student documentation for the Computing, Electronics and Robotics Summer School.",
     favicon: "img/favicon.ico",
 
     url: "https://sp.roboticsoutreach.org/",
@@ -81,4 +81,3 @@ const config: Config = {
 };
 
 export default config;
-

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,4 +1,4 @@
-# Smallpeice Docs
+# Summer School Docs
 
 This documentation explains how to use the kit and the robot's Python API.
 
@@ -33,4 +33,3 @@ It would be advisable to take note of these - especially that last one! You will
 :::info
 Some useful information
 :::
-

--- a/src/pages/rules.mdx
+++ b/src/pages/rules.mdx
@@ -1,5 +1,5 @@
 # Rules
 
-You can find the rules for Smallpeice 2024 competition here!:
+You can find the rules for 2024 competition here!:
 
 [View the rules](https://sourcebots.github.io/smallpeice-rules/)


### PR DESCRIPTION
Remove references to "Smallpeice". I've tried to do this in such a way that for future Smallpeice events, this PR doesn't necessarily need reverting, as naming still makes sense.

Note that anything about the repository is left as-is.